### PR TITLE
Extend metadata render to support arbitrary player count.

### DIFF
--- a/quoridor.py
+++ b/quoridor.py
@@ -1,13 +1,14 @@
 from src.assemble_board import assemble_board_component_groups
-from src.utils import display_player_walls
 from src.player import Player
 from pygame.sprite import Group
 from src.constants import *
 import pygame
 
+DEFAULT_FONT_SIZE = 32
+
 
 class Quoridor:
-    def __init__(self, players=None):
+    def __init__(self, players=None, font_size=DEFAULT_FONT_SIZE):
         pygame.init()
         pygame.display.set_caption("Quoridor")
         self.screen = pygame.display.set_mode((SCREEN_SIZE_X, SCREEN_SIZE_Y))
@@ -18,21 +19,22 @@ class Quoridor:
             self.players = players
         self.player_group = Group()
         self.player_group.add(self.players)
+        self.font_size = font_size
+        self.font = pygame.font.SysFont(None, font_size)
 
     @staticmethod
     def default_players():
         return [
-            Player(player_number=1, color=pygame.Color("coral"), position=(GAME_SIZE*0.5, HALF_DISTANCE), radius=0.5*CELL),
-            Player(player_number=2, color=pygame.Color("blue"), position=(GAME_SIZE*0.5, GAME_SIZE - HALF_DISTANCE), radius=0.5*CELL)
+            Player(name="Player 1", color=pygame.Color("coral"), position=(GAME_SIZE*0.5, HALF_DISTANCE), radius=0.5*CELL),
+            Player(name="Player 2", color=pygame.Color("blue"), position=(GAME_SIZE*0.5, GAME_SIZE - HALF_DISTANCE), radius=0.5*CELL),
+            Player(name="Player 3", color=pygame.Color("blue"), position=(GAME_SIZE*0.5, GAME_SIZE - HALF_DISTANCE), radius=0.5*CELL)
         ]
 
     def play_game(self):
-        current_player = 1
+        current_player_index = 0
         while True:
-            current_player_index = current_player - 1
-
-            player = self.players[current_player_index]
-            if player.is_ai:
+            current_player = self.players[current_player_index]
+            if current_player.is_ai:
                 raise RuntimeError("AI unimplemented")
                 # TODO: implement
                 # while True:
@@ -47,15 +49,33 @@ class Quoridor:
                         if event.type == pygame.QUIT:
                             pygame.quit()
                             quit()
-                        success = player.update(event, self.nodes, self.walls, self.players)
+                        success = current_player.update(event, self.nodes, self.walls, self.players)
+                    self._render(current_player)                     
+                   
+            current_player_index = (current_player_index + 1) % len(self.players)
 
-                    self.screen.fill(WHITE)
-                    self.walls.update()
-                    self.walls.draw(self.screen)
-                    self.nodes.draw(self.screen)
-                    self.player_group.draw(self.screen)
-                    display_player_walls(player_group=self.player_group, screen=self.screen, cur_play=current_player)
-                    pygame.display.flip()
+    def _render(self, current_player: Player):
+        self.screen.fill(WHITE)
+        self.walls.update()
+        self.walls.draw(self.screen)
+        self.nodes.draw(self.screen)
+        self.player_group.draw(self.screen)
+        self._render_metadata(current_player)
+        pygame.display.flip()
+    
+    def _render_metadata(self, current_player: Player):
+        self.screen.blit(
+            self.font.render(f"Current player: {current_player.name}", False, (0, 0, 0)), 
+            (GAME_SIZE, 0)
+        )
+        for i, player in enumerate(self.players):
+            row = self.font_size * (i + 1) * 2
+            self.screen.blit(
+                self.font.render(f"{player.name}", False, (0, 0, 0)),
+                (GAME_SIZE, row)
+            )
+            self.screen.blit(
+                self.font.render(f"Total walls: {player.total_walls}", False, (0, 0, 0)), 
+                (GAME_SIZE + 20, row + self.font_size)
+            )
 
-
-            current_player = (current_player % len(self.players)) + 1

--- a/src/player.py
+++ b/src/player.py
@@ -6,10 +6,10 @@ class Player(pygame.sprite.Sprite):
     total_walls = 10
     valid_directions = [pygame.K_UP, pygame.K_DOWN, pygame.K_LEFT, pygame.K_RIGHT]
 
-    def __init__(self, player_number, position, color, radius, is_ai=False):
+    def __init__(self, name, position, color, radius, is_ai=False):
         pygame.sprite.Sprite.__init__(self)
+        self.name = name
         self.radius = radius
-        self.player_number = player_number
         self.image = pygame.Surface((radius * 2, radius * 2), pygame.SRCALPHA)
         pygame.draw.circle(self.image, color, (radius, radius), radius)
         self.rect = self.image.get_rect(center=position)
@@ -55,22 +55,22 @@ class Player(pygame.sprite.Sprite):
         proximal_node = get_proximal_object(self.rect.center, node_direction, nodes)
         proximal_wall = get_proximal_object(self.rect.center, wall_direction, walls)
 
-        if proximal_wall:
-            if not proximal_wall.is_occupied:
-                if proximal_node:
-                    if not proximal_node.is_occupied:
-                        self.rect.center = proximal_node.rect.center
-                        proximal_node.is_occupied = True
-                        current_node.is_occupied = False
-                        return True
-                    else:
-                        next_proximal_wall = get_proximal_object(proximal_node.rect.center, wall_direction, walls)
-                        if next_proximal_wall and not next_proximal_wall.is_occupied:
-                            next_proximal_node = get_proximal_object(proximal_node.rect.center, node_direction, nodes)
-                            self.rect.center = next_proximal_node.rect.center
-                            next_proximal_node.is_occupied = True
-                            current_node.is_occupied = False
-                            return True
+        if not proximal_wall or proximal_wall.is_occupied or not proximal_node:
+            return False
+    
+        if not proximal_node.is_occupied:
+            self.rect.center = proximal_node.rect.center
+            proximal_node.is_occupied = True
+            current_node.is_occupied = False
+            return True
+
+        next_proximal_wall = get_proximal_object(proximal_node.rect.center, wall_direction, walls)
+        if next_proximal_wall and not next_proximal_wall.is_occupied:
+            next_proximal_node = get_proximal_object(proximal_node.rect.center, node_direction, nodes)
+            self.rect.center = next_proximal_node.rect.center
+            next_proximal_node.is_occupied = True
+            current_node.is_occupied = False
+            return True
 
         return False
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -79,24 +79,3 @@ def check_viable_path(nodes, walls, player):
                         stack.append(neighboring_node.position)
 
     return False
-
-
-def display_player_walls(player_group, screen, cur_play, font_size=32):
-    my_font = pygame.font.SysFont(None, font_size)
-    coordinates = {
-        'player_1': {'walls_remaining': (GAME_SIZE + 20, font_size*2), 'title': (GAME_SIZE, font_size)},
-        'player_2': {'walls_remaining': (GAME_SIZE + 20, font_size*4), 'title': (GAME_SIZE, font_size*3)}
-    }
-    for i, player in enumerate(player_group):
-        text_curr_player = my_font.render(f"Curr Player: {cur_play}", False, (0, 0, 0))
-        text_surface_title = my_font.render(f"Player {player.player_number}", False, (0, 0, 0))
-        text_surface_walls = my_font.render(f"Total Walls {player.total_walls}", False, (0, 0, 0))
-        if i == 0:
-            coords = coordinates['player_1']
-        else:
-            coords = coordinates['player_2']
-        screen.blit(text_surface_title, coords['title'])
-        screen.blit(text_surface_walls, coords['walls_remaining'])
-        screen.blit(text_curr_player, (GAME_SIZE + 20, font_size * 6))
-
-


### PR DESCRIPTION
Metadata pane rendering code's been cleaned up and can support rendering an arbitrary number of players with their customized names.

<img width="403" alt="image" src="https://github.com/btbeal/quoridor/assets/33734832/422f8875-92fa-4315-bb3f-b2a166f7ef79">
